### PR TITLE
Add embedding migration CLI option

### DIFF
--- a/cobrapinger.py
+++ b/cobrapinger.py
@@ -853,6 +853,25 @@ def process_missing_advisor_notes(config, client):
             
     log("Finished processing advisor notes.")
 
+def migrate_embeddings(config, client):
+    """Upload all stored embeddings to the configured vector store."""
+    db = DatabaseManager(config['db_path'])
+    vector_store = VectorStoreManager(client, config['vector_store_id'])
+    embeddings = db.get_all_embeddings()
+    if not embeddings:
+        log("No embeddings found in the database.")
+        return
+
+    count = 0
+    for video_id, embedding in embeddings:
+        try:
+            vector_store.store_embedding(video_id, embedding)
+            count += 1
+        except Exception as e:
+            log(f"Failed to migrate embedding for video {video_id}: {e}")
+
+    log(f"Migrated {count} embeddings to vector store.")
+
 def ask_question(config, client):
     """Allow the user to ask a question about the video library."""
     db = DatabaseManager(config['db_path'])
@@ -899,7 +918,8 @@ def show_menu():
         print("12. Generate invite code")
         print("13. Generate Missing Advisor Notes")  # Add this line
         print("14. Ask a Question")
-        print("15. Exit")  # Update exit number
+        print("15. Migrate Embeddings")
+        print("16. Exit")
         choice = input("Enter your choice: ")
 
         if choice == "1":
@@ -934,7 +954,9 @@ def show_menu():
             process_missing_advisor_notes(config, client)
         elif choice == "14":
             ask_question(config, client)
-        elif choice == "15":  # Update exit number
+        elif choice == "15":
+            migrate_embeddings(config, client)
+        elif choice == "16":
             break
         else:
             print("Invalid choice. Please try again.")
@@ -943,7 +965,12 @@ if __name__ == "__main__":
     import sys
     config = load_config()
     client = OpenAI(api_key=config['openai_api_key'])
-    if len(sys.argv) > 1 and sys.argv[1] == "--auto":
-        run_program_continuously(config, client)
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "--auto":
+            run_program_continuously(config, client)
+        elif sys.argv[1] == "--migrate-embeds":
+            migrate_embeddings(config, client)
+        else:
+            show_menu()
     else:
         show_menu()

--- a/database.py
+++ b/database.py
@@ -146,6 +146,15 @@ class DatabaseManager:
             row = cursor.fetchone()
             return json.loads(row[0]) if row else None
 
+    def get_all_embeddings(self) -> list[tuple[int, list[float]]]:
+        """Retrieve all embeddings stored in the database."""
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT video_id, embedding FROM video_embedding")
+            rows = cursor.fetchall()
+        return [(row[0], json.loads(row[1])) for row in rows]
+
+
     def search_by_embedding(self, embedding: list[float], top_n: int = 5) -> list[dict]:
         """Return videos most similar to the given embedding."""
         with sqlite3.connect(self.db_path) as conn:


### PR DESCRIPTION
## Summary
- enable listing all stored embeddings from the database
- add a `migrate_embeddings` helper
- expose migration in the menu and via `--migrate-embeds` CLI argument

## Testing
- `python -m py_compile cobrapinger.py database.py vector_store.py`

------
https://chatgpt.com/codex/tasks/task_e_684640d06f5483239f32c1a195927c9c